### PR TITLE
#369 ユーザー新規登録の3日後に、管理人からダイレクトメッセージを自動で送るプラグイン開発

### DIFF
--- a/auto-pmsg-db-client.php
+++ b/auto-pmsg-db-client.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit;
+}
+
+require_once QA_INCLUDE_DIR.'db/users.php';
+require_once QA_INCLUDE_DIR.'db/selects.php';
+
+class q2a_auto_pmsg_db_client
+{
+    public static function get_users_day_after_registration($day = 3)
+    {
+        $sql = "SELECT userid, handle, email";
+        $sql .= " FROM ^users";
+        $sql .= " WHERE (flags & #) = 0";
+        $sql .= " AND DATE_FORMAT(created, '%Y-%m-%d') LIKE DATE_FORMAT((NOW() - INTERVAL # DAY), '%Y-%m-%d')";
+        // ブロックユーザーを含めない
+        $flag = QA_USER_FLAGS_USER_BLOCKED;
+        return qa_db_read_all_assoc(qa_db_query_sub($sql, $flag, $day));
+    }
+    
+    public static function is_user_posted($userid)
+    {
+        $sql = "SELECT count(*)";
+        $sql .= " FROM ^posts";
+        $sql .= " WHERE userid = #";
+        $result = qa_db_read_one_value(qa_db_query_sub($sql, $userid));
+        if (isset($result) && $result > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/auto-pmsg-script.php
+++ b/auto-pmsg-script.php
@@ -4,13 +4,13 @@ if (!defined('QA_VERSION')) {
     require_once dirname(empty($_SERVER['SCRIPT_FILENAME']) ? __FILE__ : $_SERVER['SCRIPT_FILENAME']).'/../../qa-include/qa-base.php';
 }
 
-require_once QA_PLUGIN_DIR.'test-plugin/test-db-client.php';
+require_once QA_PLUGIN_DIR.'q2a-auto-pmsg/auto-pmsg-db-client.php';
 require_once QA_INCLUDE_DIR.'db/messages.php';
 require_once QA_INCLUDE_DIR.'app/emails.php';
 
 error_log('start send direct message'.PHP_EOL);
 
-$users = q2a_dm_db_client::get_users_day_after_registration();
+$users = q2a_auto_pmsg_db_client::get_users_day_after_registration();
 
 
 foreach ($users as $user) {
@@ -21,7 +21,7 @@ foreach ($users as $user) {
     }
     $fromuserid = qa_handle_to_userid($fromhandle);
     
-    if (q2a_dm_db_client::is_user_posted($user['userid'])) {
+    if (q2a_auto_pmsg_db_client::is_user_posted($user['userid'])) {
         $message = qa_opt('qa_auto_pmsg_message_for_posted');
     } else {
         $message = qa_opt('qa_auto_pmsg_message_for_no_posted');

--- a/auto-pmsg-script.php
+++ b/auto-pmsg-script.php
@@ -1,0 +1,43 @@
+<?php
+
+if (!defined('QA_VERSION')) {
+    require_once dirname(empty($_SERVER['SCRIPT_FILENAME']) ? __FILE__ : $_SERVER['SCRIPT_FILENAME']).'/../../qa-include/qa-base.php';
+}
+
+require_once QA_PLUGIN_DIR.'test-plugin/test-db-client.php';
+require_once QA_INCLUDE_DIR.'db/messages.php';
+require_once QA_INCLUDE_DIR.'app/emails.php';
+
+error_log('start send direct message'.PHP_EOL);
+
+$users = q2a_dm_db_client::get_users_day_after_registration();
+
+
+foreach ($users as $user) {
+    
+    $fromhandle = qa_opt('qa_auto_pmsg_from_handle');
+    if (empty($fromhandle)) {
+        $fromhandle = '管理人';
+    }
+    $fromuserid = qa_handle_to_userid($fromhandle);
+    
+    if (q2a_dm_db_client::is_user_posted($user['userid'])) {
+        $message = qa_opt('qa_auto_pmsg_message_for_posted');
+    } else {
+        $message = qa_opt('qa_auto_pmsg_message_for_no_posted');
+    }
+    
+    if (qa_opt('show_message_history'))
+        $messageid = qa_db_message_create($fromuserid, $user['userid'], $message, '', false);
+    else
+        $messageid = null;
+
+    qa_report_event('u_message', $fromuserid, $fromhandle, null, array(
+        'userid' => $user['userid'],
+        'handle' => $user['handle'],
+        'messageid' => $messageid,
+        'message' => $message,
+    ));
+}
+
+error_log('end send direct message'.PHP_EOL);

--- a/qa-auto-pmsg-admin.php
+++ b/qa-auto-pmsg-admin.php
@@ -1,0 +1,68 @@
+<?php
+
+class qa_auto_pmsg_admin
+{
+	public function option_default($option)
+	{
+		switch ($option) {
+			case 'qa_auto_pmsg_from_handle':
+				return '管理人';
+			case 'qa_auto_pmsg_message_for_posted':
+				return '投稿しているユーザー向けメッセージ内容';
+			case 'qa_auto_pmsg_message_for_no_posted':
+				return 'まだ投稿していないユーザー向けメッセージ内容';
+			default:
+				return;
+		}
+	}
+
+	public function allow_template($template)
+	{
+		return $template != 'admin';
+	}
+
+	public function admin_form(&$qa_content)
+	{
+		// process the admin form if admin hit Save-Changes-button
+		$ok = null;
+		if (qa_clicked('qa_auto_pmsg_save')) {
+			qa_opt('qa_auto_pmsg_from_handle', qa_post_text('qa_auto_pmsg_from_handle'));
+			$ok = qa_lang('admin/options_saved');
+		}
+
+		// form fields to display frontend for admin
+		$fields = array();
+
+		$fields[] = array(
+			'label' => '送信者名（ハンドル）',
+			'tags' => 'NAME="qa_auto_pmsg_from_handle"',
+			'value' => qa_opt('qa_auto_pmsg_from_handle'),
+			'type' => 'text'
+		);
+		
+		$fields[] = array(
+			'label' => '投稿有りユーザー向け',
+			'tags' => 'name="qa_auto_pmsg_message_for_posted"',
+			'value' => qa_opt('qa_auto_pmsg_message_for_posted'),
+			'type' => 'textarea',
+		);
+		
+		$fields[] = array(
+			'label' => '投稿なしユーザー向け',
+			'tags' => 'name="qa_auto_pmsg_message_for_no_posted"',
+			'value' => qa_opt('qa_auto_pmsg_message_for_no_posted'),
+			'type' => 'textarea',
+		);
+
+		return array(
+			'ok' => ($ok && !isset($error)) ? $ok : null,
+			'fields' => $fields,
+			'buttons' => array(
+				array(
+					'label' => qa_lang_html('main/save_button'),
+					'tags' => 'name="qa_auto_pmsg_save"',
+				),
+			),
+		);
+	}
+}

--- a/qa-auto-pmsg-admin.php
+++ b/qa-auto-pmsg-admin.php
@@ -34,21 +34,21 @@ class qa_auto_pmsg_admin
 		$fields = array();
 
 		$fields[] = array(
-			'label' => '送信者名（ハンドル）',
+			'label' => qa_lang_html('qa_apmsg_lang/from_handle'),
 			'tags' => 'NAME="qa_auto_pmsg_from_handle"',
 			'value' => qa_opt('qa_auto_pmsg_from_handle'),
 			'type' => 'text'
 		);
 		
 		$fields[] = array(
-			'label' => '投稿有りユーザー向け',
+			'label' => qa_lang_html('qa_apmsg_lang/to_posted_user'),
 			'tags' => 'name="qa_auto_pmsg_message_for_posted"',
 			'value' => qa_opt('qa_auto_pmsg_message_for_posted'),
 			'type' => 'textarea',
 		);
 		
 		$fields[] = array(
-			'label' => '投稿なしユーザー向け',
+			'label' => qa_lang_html('qa_apmsg_lang/to_no_posted_user'),
 			'tags' => 'name="qa_auto_pmsg_message_for_no_posted"',
 			'value' => qa_opt('qa_auto_pmsg_message_for_no_posted'),
 			'type' => 'textarea',

--- a/qa-auto-pmsg-lang-default.php
+++ b/qa-auto-pmsg-lang-default.php
@@ -1,0 +1,6 @@
+<?php
+return array(
+	'from_handle' => '送信者名（ハンドル）',
+	'to_posted_user' => '投稿しているユーザー向け',
+	'to_no_posted_user' => 'まだ投稿していないユーザー向け'
+);

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+	Plugin Name: Auto PMSG
+	Plugin URI: 
+	Plugin Description: Automatically send direct message from administrator
+	Plugin Version: 1.0
+	Plugin Date: 2016-11-15
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://38qa.net/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// // language
+// qa_register_plugin_phrases('qa-auto-save-lang-*.php', 'qa_as_lang');
+// admin
+qa_register_plugin_module('module', 'qa-auto-pmsg-admin.php', 'q2a_auto_pmsg_admin', 'Auto PMSG Admin');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -18,7 +18,7 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
-// // language
-// qa_register_plugin_phrases('qa-auto-save-lang-*.php', 'qa_as_lang');
+// language
+qa_register_plugin_phrases('qa-auto-pmsg-lang-*.php', 'qa_apmsg_lang');
 // admin
-qa_register_plugin_module('module', 'qa-auto-pmsg-admin.php', 'q2a_auto_pmsg_admin', 'Auto PMSG Admin');
+qa_register_plugin_module('module', 'qa-auto-pmsg-admin.php', 'qa_auto_pmsg_admin', 'Auto PMSG Admin');


### PR DESCRIPTION
* 新規登録3日後のユーザーが対象
* cronで実行
* qa_sn_notice, qa_sn_event に登録されるので通知なども送られる
* 投稿しているかしていないかでメッセージ内容が変わる
* メッセージ内容は管理画面で設定
* 送信元(from)のユーザー名(handle)も管理画面で設定できる。デフォルトは「管理人」