### PR TITLE
翻訳ファイルのカンマ忘れのbug fix

### DIFF
--- a/qa-auto-pmsg-lang-default.php
+++ b/qa-auto-pmsg-lang-default.php
@@ -2,7 +2,7 @@
 return array(
 	'from_handle' => '送信者名（ハンドル）',
 	'to_posted_user' => '投稿しているユーザー向け',
-	'to_no_posted_user' => 'まだ投稿していないユーザー向け'
+	'to_no_posted_user' => 'まだ投稿していないユーザー向け',
 	'default_handle' => '管理人',
 	'default_for_posted' => '投稿しているユーザー向けメッセージ',
 	'default_for_no_post' => '投稿していないユーザー向けメッセージ',


### PR DESCRIPTION
プラグイン管理画面から設定を開こうとするとエラーが発生
yaimappさんの環境のソースを見ると古いままになっていたため、動いていました。